### PR TITLE
Remove trailing slash from endpoint if it exists

### DIFF
--- a/h5pyd/_hl/files.py
+++ b/h5pyd/_hl/files.py
@@ -190,6 +190,10 @@ class File(Group):
                 elif "hs_endpoint" in cfg:
                     endpoint = cfg["hs_endpoint"]
 
+            # remove the trailing slash on endpoint if it exists
+            if endpoint.endswith('/'):
+                endpoint = endpoint.strip('/')
+                
             if username is None:
                 if "H5SERV_USERNAME" in os.environ:
                     username = os.environ["H5SERV_USERNAME"]


### PR DESCRIPTION
As noted in #105, this PR will remove the trailing slash from the `endpoint` parameter if it exists. This will prevent the exception from being thrown if the slash exists. 